### PR TITLE
Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Growth Engineers Toolkit
-A Growth Engineers' Toolkit, helping in spotting technical SEO issues, and running other growth activities.
+A Growth Engineers' Toolkit, helping in spotting technical SEO issues and running other growth activities.
 
-[Download the Chrome Extension](https://chromewebstore.google.com/detail/growth-toolkit/klbjmnodglnjjogehfpjabpbbcligdio?authuser=0&hl=en)
+[Download the Chrome Extension](https://chromewebstore.google.com/detail/growth-toolkit-technical/klbjmnodglnjjogehfpjabpbbcligdio)
 
 ## 🚀 Benefits
 - Meta Tag Issues: Shows all the meta tags and highlights the ones with issues.


### PR DESCRIPTION
## Summary
- update Chrome extension link in README to avoid redirect

## Testing
- `apt-get update`
- `apt-get install -y xxd`

------
https://chatgpt.com/codex/tasks/task_e_683f3b8eb124832db31c0047156949ab